### PR TITLE
puts updateInstructions action creator back in Build.js mapDispatch func.

### DIFF
--- a/src/screens/Build.js
+++ b/src/screens/Build.js
@@ -544,6 +544,8 @@ const mapDispatch = dispatch => {
     rotateDrone: newOrientation => {
       dispatch(rotateDrone(newOrientation));
     },
+    updateInstructions: updatedFlightInstructions =>
+      dispatch(updateInstructions(updatedFlightInstructions)),
   };
 };
 


### PR DESCRIPTION
updateInstructions action creator was somehow removed from the mapDispatch function for Build.js. it is definitely needed, so this commit puts it back.